### PR TITLE
fix: ignore blocking reasons

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/util/parsers/BikeCommonAccessParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/BikeCommonAccessParser.java
@@ -76,7 +76,7 @@ public abstract class BikeCommonAccessParser extends AbstractAccessParser implem
 
         String sacScale = way.getTag("sac_scale");
         if (sacScale != null) {
-            if (!isSacScaleAllowed(sacScale) && !way.hasTag("bicycle")) {
+            if (!isSacScaleAllowed(sacScale) && !way.hasTag("bicycle") && !way.hasTag("surface", "asphalt")) {
                 return WayAccess.CAN_SKIP;
             }
         }

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMGetOffBikeParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMGetOffBikeParser.java
@@ -1,17 +1,17 @@
 package com.graphhopper.routing.util.parsers;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+
 import com.graphhopper.reader.ReaderWay;
 import com.graphhopper.routing.ev.BooleanEncodedValue;
 import com.graphhopper.routing.ev.EdgeIntAccess;
 import com.graphhopper.storage.IntsRef;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-
 /**
- * This parser scans different OSM tags to identify ways where a cyclist has to get off her bike. Like on footway but
- * also in reverse oneway direction.
+ * This parser scans different OSM tags to identify ways where a cyclist has to
+ * get off her bike. Like on footway but also in reverse oneway direction.
  */
 public class OSMGetOffBikeParser implements TagParser {
 
@@ -22,7 +22,8 @@ public class OSMGetOffBikeParser implements TagParser {
     private final BooleanEncodedValue bikeAccessEnc;
 
     /**
-     * @param bikeAccessEnc used to find out if way is oneway and so it does not matter which bike type is used.
+     * @param bikeAccessEnc used to find out if way is oneway and so it does not
+     * matter which bike type is used.
      */
     public OSMGetOffBikeParser(BooleanEncodedValue getOffBikeEnc, BooleanEncodedValue bikeAccessEnc) {
         this.getOffBikeEnc = getOffBikeEnc;
@@ -32,14 +33,14 @@ public class OSMGetOffBikeParser implements TagParser {
     @Override
     public void handleWayTags(int edgeId, EdgeIntAccess edgeIntAccess, ReaderWay way, IntsRef relationFlags) {
         String highway = way.getTag("highway");
-        String vehicle = way.getTag("vehicle", "");
-        boolean notIntended = !way.hasTag("bicycle", INTENDED) &&
-                (GET_OFF_BIKE.contains(highway)
-                        || way.hasTag("railway", "platform")
-                        || !"cycleway".equals(highway) && way.hasTag("vehicle", "no")
-                        || vehicle.contains("forestry")
-                        || vehicle.contains("agricultural")
-                        || "path".equals(highway) && way.hasTag("foot", "designated") && !way.hasTag("segregated", "yes"));
+        // String vehicle = way.getTag("vehicle", "");
+        boolean notIntended = !way.hasTag("bicycle", INTENDED)
+                && (GET_OFF_BIKE.contains(highway)
+                || way.hasTag("railway", "platform")
+                || !"cycleway".equals(highway) && way.hasTag("vehicle", "no")
+                // || vehicle.contains("forestry")
+                // || vehicle.contains("agricultural")
+                || "path".equals(highway) && way.hasTag("foot", "designated") && !way.hasTag("segregated", "yes"));
         if ("steps".equals(highway) || way.hasTag("bicycle", "dismount") || notIntended) {
             getOffBikeEnc.setBool(false, edgeId, edgeIntAccess, true);
             getOffBikeEnc.setBool(true, edgeId, edgeIntAccess, true);
@@ -48,8 +49,12 @@ public class OSMGetOffBikeParser implements TagParser {
         boolean bwd = bikeAccessEnc.getBool(true, edgeId, edgeIntAccess);
         // get off bike for reverse oneways
         if (fwd != bwd) {
-            if (!fwd) getOffBikeEnc.setBool(false, edgeId, edgeIntAccess, true);
-            if (!bwd) getOffBikeEnc.setBool(true, edgeId, edgeIntAccess, true);
+            if (!fwd) {
+                getOffBikeEnc.setBool(false, edgeId, edgeIntAccess, true);
+            }
+            if (!bwd) {
+                getOffBikeEnc.setBool(true, edgeId, edgeIntAccess, true);
+            }
         }
     }
 }

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMRoadAccessParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMRoadAccessParser.java
@@ -17,22 +17,22 @@
  */
 package com.graphhopper.routing.util.parsers;
 
-import com.graphhopper.reader.ReaderWay;
-import com.graphhopper.routing.ev.EdgeIntAccess;
-import com.graphhopper.routing.ev.EnumEncodedValue;
-import com.graphhopper.routing.ev.RoadAccess;
-import com.graphhopper.routing.util.TransportationMode;
-import com.graphhopper.routing.util.countryrules.CountryRule;
-import com.graphhopper.storage.IntsRef;
-
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.ev.EdgeIntAccess;
+import com.graphhopper.routing.ev.EnumEncodedValue;
+import com.graphhopper.routing.ev.RoadAccess;
 import static com.graphhopper.routing.ev.RoadAccess.YES;
+import com.graphhopper.routing.util.TransportationMode;
+import com.graphhopper.routing.util.countryrules.CountryRule;
+import com.graphhopper.storage.IntsRef;
 
 public class OSMRoadAccessParser implements TagParser {
+
     protected final EnumEncodedValue<RoadAccess> roadAccessEnc;
     private final List<String> restrictions;
 
@@ -47,19 +47,23 @@ public class OSMRoadAccessParser implements TagParser {
 
         List<Map<String, Object>> nodeTags = readerWay.getTag("node_tags", Collections.emptyList());
         // a barrier edge has the restriction in both nodes and the tags are the same
-        if (readerWay.hasTag("gh:barrier_edge"))
+        if (readerWay.hasTag("gh:barrier_edge")) {
             for (String restriction : restrictions) {
                 Object value = nodeTags.get(0).get(restriction);
-                if (value != null) accessValue = getRoadAccess((String) value, accessValue);
+                if (value != null) {
+                    accessValue = getRoadAccess((String) value, accessValue);
+                }
             }
+        }
 
         for (String restriction : restrictions) {
             accessValue = getRoadAccess(readerWay.getTag(restriction), accessValue);
         }
 
         CountryRule countryRule = readerWay.getTag("country_rule", null);
-        if (countryRule != null)
+        if (countryRule != null) {
             accessValue = countryRule.getAccess(readerWay, TransportationMode.CAR, accessValue);
+        }
 
         roadAccessEnc.setEnum(false, edgeId, edgeIntAccess, accessValue);
     }
@@ -85,7 +89,7 @@ public class OSMRoadAccessParser implements TagParser {
             case VEHICLE:
                 return Arrays.asList("vehicle", "access");
             case BIKE:
-                return Arrays.asList("bicycle", "access");
+                return Arrays.asList("bicycle");
             case CAR:
                 return Arrays.asList("motorcar", "motor_vehicle", "vehicle", "access");
             case MOTORCYCLE:

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/RacingBikeAccessParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/RacingBikeAccessParser.java
@@ -11,7 +11,7 @@ public class RacingBikeAccessParser extends BikeCommonAccessParser {
     public RacingBikeAccessParser(EncodedValueLookup lookup, PMap properties) {
         this(lookup.getBooleanEncodedValue(VehicleAccess.key("racingbike")),
                 lookup.getBooleanEncodedValue(Roundabout.KEY));
-        blockPrivate(properties.getBool("block_private", true));
+        blockPrivate(properties.getBool("block_private", false));
         blockFords(properties.getBool("block_fords", false));
     }
 


### PR DESCRIPTION
Lot's of barriers, lift gates and other blocking entities are placed incorrectly on the map and make if difficult to navigate existing climbs. We ignore them for now to prevent broken climbs.